### PR TITLE
fix: avoid panic when finding next parts

### DIFF
--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-16.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-16.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0\").unwrap_err()"
+---
+malformed expression:
+0
+ ^ missing hours

--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-17.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-17.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0 0\").unwrap_err()"
+---
+malformed expression:
+0 0
+   ^ missing days of month

--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-18.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-18.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0 0 1\").unwrap_err()"
+---
+malformed expression:
+0 0 1
+     ^ missing months

--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-19.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-19.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0 0 1 1\").unwrap_err()"
+---
+malformed expression:
+0 0 1 1
+       ^ missing days of week

--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-20.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-20.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0 0 1 1 5\").unwrap_err()"
+---
+malformed expression:
+0 0 1 1 5
+         ^ missing timezone

--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-21.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-21.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0 0 1 1 5 \").unwrap_err()"
+---
+malformed expression:
+0 0 1 1 5
+         ^ missing timezone

--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-22.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-22.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0 0 1 1 5 Z\").unwrap_err()"
+---
+failed to parse crontab expression:
+0 0 1 1 5 Z
+          ^ failed to find timezone Z; for a list of time zones, see the list of tz database time zones on Wikipedia: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List

--- a/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-23.snap
+++ b/src/snapshots/cronexpr__parser__tests__parse_crontab_failed-23.snap
@@ -1,0 +1,7 @@
+---
+source: src/parser.rs
+expression: "parse_crontab(\"0 0 1 1 5 Z Z\").unwrap_err()"
+---
+failed to parse crontab expression:
+0 0 1 1 5 Z Z
+          ^ failed to find timezone Z Z; for a list of time zones, see the list of tz database time zones on Wikipedia: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List


### PR DESCRIPTION
This closes https://github.com/tisonkun/cronexpr/pull/9.

@haoqixu your patch is integrated here since I use a different way that handle panic more tidy.