### PR TITLE
chore: mark FallbackTimezoneOption as non_exhaustive

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,6 +41,7 @@ use crate::PossibleValue;
 /// Determine the timezone to fallback when the timezone part is missing.
 ///
 /// See also examples in the [`parse_crontab_with`] documentation.
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum FallbackTimezoneOption {
     /// Do not fall back to any timezone. This means the timezone part is required.


### PR DESCRIPTION
Although this is less likely to be extended, I'd try to mark it as `non_exhaustive`.

Typically, people only pass a certain variant to construct a `ParseOptions`. This only affect when people try to match against variants and then they should handle the `_` cases always.

This is related to #16 #18 #19.