### PR TITLE
build: upgrade jiff to 0.2 and bump MSRV to 1.80

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust-version: [ "1.75.0", "stable" ]
+        rust-version: [ "1.80.0", "stable" ]
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "cronexpr"
-version = "1.1.5"
+version = "1.2.0"
 dependencies = [
  "insta",
  "jiff",
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.1.28"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c607c728e28764fecde611a2764a3a5db19ae21dcec46f292244f5cc5c085a81"
+checksum = "ba926fdd8e5b5e7f9700355b0831d8c416afe94b014b1023424037a187c9c582"
 dependencies = [
  "jiff-tzdb-platform",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "cronexpr"
-version = "1.1.5"
+version = "1.2.0"
 
 description = "A library to parse and drive the crontab expression."
 edition = "2021"
@@ -22,14 +22,14 @@ homepage = "https://github.com/cratesland/cronexpr"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/cratesland/cronexpr"
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-jiff = { version = "0.1.28" }
+jiff = { version = "0.2.0" }
 thiserror = { version = "2.0.11" }
 winnow = { version = "0.7.0" }
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
-[![MSRV 1.75][msrv-badge]](https://www.whatrustisit.com)
+[![MSRV 1.80][msrv-badge]](https://www.whatrustisit.com)
 [![Apache 2.0 licensed][license-badge]][license-url]
 [![Build Status][actions-badge]][actions-url]
 
 [crates-badge]: https://img.shields.io/crates/v/cronexpr.svg
 [crates-url]: https://crates.io/crates/cronexpr
 [docs-badge]: https://docs.rs/cronexpr/badge.svg
-[msrv-badge]: https://img.shields.io/badge/MSRV-1.75-green?logo=rust
+[msrv-badge]: https://img.shields.io/badge/MSRV-1.80-green?logo=rust
 [docs-url]: https://docs.rs/cronexpr
 [license-badge]: https://img.shields.io/crates/l/cronexpr
 [license-url]: LICENSE
@@ -108,7 +108,7 @@ If you are using `cronexpr` in your project, please feel free to open a PR to ad
 
 ## Minimum Rust version policy
 
-This crate is built against the latest stable release, and its minimum supported rustc version is 1.75.0.
+This crate is built against the latest stable release, and its minimum supported rustc version is 1.80.0.
 
 The policy is that the minimum Rust version required to use this crate can be increased in minor version updates. For example, if cronexpr 1.0 requires Rust 1.20.0, then cronexpr 1.0.z for all values of z will also require Rust 1.20.0 or newer. However, cronexpr 1.y for y > 0 may require a newer minimum version of Rust.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,8 @@ pub use parser::parse_crontab_with;
 pub use parser::FallbackTimezoneOption;
 pub use parser::ParseOptions;
 
+pub extern crate jiff;
+
 /// An error that can occur in this crate.
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("{0}")]


### PR DESCRIPTION
+ Export jiff so that one using the `jiff::Zoned` returned from this crate can use the jiff type export from this crate also.

This isn't considered a semver breaking change as the use case of the returned type should be simple.